### PR TITLE
feat: use binary sccache

### DIFF
--- a/src/sccache/devcontainer-feature.json
+++ b/src/sccache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "sccache",
     "id": "sccache",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "sccache is a compiler cache. It caches build artifacts for C, C++, and Rust, allowing for faster builds in subsequent runs.",
     "options": {},
     "dependsOn": {

--- a/src/sccache/install.sh
+++ b/src/sccache/install.sh
@@ -4,32 +4,7 @@ set -e
 echo "Activating feature 'sccache'"
 
 # The 'install.sh' entrypoint script is always executed as the root user.
-install_debian_dependencies() {
-  echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-  apt-get update
-  apt-get install -y libssl-dev pkg-config
+curl -L --proto '=https' --tlsv1.2 -sSf \
+  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
-  apt-get clean && rm -rf /var/lib/apt/lists/*
-}
-
-# Detemine the distro we're on by using /etc/os-release
-if [ -f /etc/os-release ]; then
-  . /etc/os-release
-  case $ID in
-    debian)
-      install_debian_dependencies
-      ;;
-    ubuntu)
-      install_debian_dependencies
-      ;;
-    *)
-      echo "Unsupported distro: $ID"
-      exit 1
-      ;;
-  esac
-else
-  echo "Unsupported distro"
-  exit 1
-fi
-
-cargo install sccache --locked --root /usr/local
+cargo binstall sccache -y --locked --root /usr/local


### PR DESCRIPTION
Previously I was building sccache from source, which took a long time during the devcontainer bring-up. This change uses cargo binstall to install a binary version instead.